### PR TITLE
fix: remove unsupported electron-builder properties

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,3 +210,21 @@ Aucune pour le moment - Configuration stockée localement.
   - **Test** : Comment tester/valider (si pertinent)
 - Éviter les descriptions trop détaillées ou verbeuses
 - Focus sur le "pourquoi" plutôt que le "comment"
+
+## 🚨 Règles Git Importantes
+
+### Commits
+- **JAMAIS de commit direct sur main** - toujours passer par des branches
+- Utiliser des branches pour toute modification : `fix/`, `feat/`, etc.
+- Merger uniquement via Pull Requests
+
+## 📝 Notes Techniques
+
+### Métadonnées Windows (à investiguer plus tard)
+- **Problème** : `publisherName` et `verInfo` non supportés dans electron-builder v26
+- **Alternatives potentielles** :
+  - `legalTrademarks` : pour informations légales 
+  - `releaseInfo` : pour métadonnées de release
+  - Downgrade electron-builder vers version qui supporte ces propriétés
+  - Configuration dans `nsis` section au lieu de `win`
+- **Status** : Ignoré pour v1.0.x, fonctionnel sans ces métadonnées

--- a/package.json
+++ b/package.json
@@ -37,13 +37,7 @@
           "arch": ["x64"]
         }
       ],
-      "icon": "assets/icons/app-icon.png",
-      "publisherName": "Alexandre Monney",
-      "verInfo": {
-        "CompanyName": "Alexandre Monney",
-        "FileDescription": "NMS Expedition Manager - Gestionnaire d'expéditions No Man's Sky",
-        "ProductName": "NMS Expedition Manager"
-      }
+      "icon": "assets/icons/app-icon.png"
     },
     "compression": "maximum",
     "nsis": {


### PR DESCRIPTION
## Problème
Build Windows échoue à cause de propriétés `publisherName` et `verInfo` non supportées dans electron-builder v26.

## Solution
Suppression des propriétés non supportées. Build testé avec succès sans elles.

## Test
- `npm run build:win` passe localement
- Configuration minimale mais fonctionnelle