### PR TITLE
fix: add GitHub token permissions for releases

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -9,6 +9,8 @@ on:
 jobs:
   build:
     runs-on: windows-latest
+    permissions:
+      contents: write
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
## Problème
Workflow échoue car le GITHUB_TOKEN automatique n'a pas les permissions pour créer des releases.

## Solution
Ajout de `permissions: contents: write` au job pour permettre la création de releases.

## Test
Le GITHUB_TOKEN est fourni automatiquement par GitHub Actions, il faut juste les bonnes permissions.