### PR TITLE
fix: correct GH_TOKEN configuration for release action

### DIFF
--- a/.github/workflows/test-release.yml
+++ b/.github/workflows/test-release.yml
@@ -32,8 +32,8 @@ jobs:
       
     - name: Test Release Creation
       uses: softprops/action-gh-release@v2
-      with:
-        token: ${{ github.token }}
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         files: |
           dist/*.exe
           dist/*.blockmap


### PR DESCRIPTION
## Problème
Test workflow échoue avec même erreur de token.

## Solution  
Utiliser `env: GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}` au lieu de `with: token: ${{ github.token }}`.

## Test
Une fois mergé, on retest avec un nouveau tag test.